### PR TITLE
bug fix where param_to_type_map was never populated causing type to b…

### DIFF
--- a/pddl_parser/src/pddl_parser.cpp
+++ b/pddl_parser/src/pddl_parser.cpp
@@ -107,6 +107,8 @@ namespace pddl_lib {
         std::string_view section;
         std::string matched_token;
         std::vector<std::string_view> all_comments;
+        
+        std::unordered_map<std::string, std::string> param_to_type_map;
 
         std::tie(section, remaining) = getNextParen(content);
         const auto strings = parseVector(section, {'\t', '\n', ' '}, all_comments);
@@ -144,6 +146,13 @@ namespace pddl_lib {
 //            return fmt::format("ERROR line {}: missing ':objects' keyword", get_line_num(content, substrings[0]));
             problem.objects = parse_instantiated_params(
                     std::vector<std::string_view>(substrings.begin() + 1, substrings.end()));
+            
+            // <-- Populate param_to_type_map here
+
+            for (auto &obj : problem.objects) {
+                param_to_type_map[obj.name] = obj.type;
+            }
+
             ind++;
             std::tie(section, remaining) = getNextParen(strings[ind]);
             substrings = parseVector(section, {'\t', '\n', ' '}, all_comments);
@@ -152,7 +161,7 @@ namespace pddl_lib {
         if (substrings[0] != ":init") {
             return fmt::format("ERROR line {}: missing ':init' keyword", get_line_num(content, substrings[0]));
         }
-        std::unordered_map<std::string, std::string> param_to_type_map;
+
         for (const auto &str: std::vector<std::string_view>(substrings.begin() + 1, substrings.end())) {
             std::tie(section, remaining) = getNextParen(str);
             auto subsubstrings = parseVector(section, {'\t', '\n', ' '}, all_comments);


### PR DESCRIPTION
When objects in the PDDL have types and load_kb is used, getPlan fails to generate any plan because the init function is not populated correctly due to a type mismatch in the parse_predicate function.

Specifically, the following code:
```
if (param_to_type_map.find(param.name) != param_to_type_map.end()) {
    param.type = param_to_type_map.at(param.name);
}
```
relies on param_to_type_map being populated, but in the original implementation this map was only initialized and never filled with values, causing the type information to be missing.